### PR TITLE
Builder pattern applied to data sources

### DIFF
--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -2,6 +2,7 @@
 from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
+from abc import ABCMeta, abstractmethod
 
 # Mapping of services to data-sources.
 DATA_SOURCES = {
@@ -9,7 +10,6 @@ DATA_SOURCES = {
     "csbs": CSBSLocationService(),
     "nyt": NYTLocationService(),
 }
-
 
 def data_source(source):
     """
@@ -19,3 +19,44 @@ def data_source(source):
     :rtype: LocationService
     """
     return DATA_SOURCES.get(source.lower())
+
+
+class LocationAssembler:
+    """The Director"""
+    builder = None
+
+    def setBuilder(self,builder):
+        self.builder = builder
+
+    def getSource(self):
+        product = LocationSource()
+        source = self.builder.getDataSource()
+        product.setDataSource(source)
+
+class LocationSource:
+    """The Product"""
+    def __init__(self):
+        self.datasource = None
+
+    def setDataSource(self, dataSource):
+        self.dataSource = dataSource
+
+class LocationSourceBuilder(metaclass=ABCMeta):
+    """The Interface"""
+    @abstractmethod
+    def getDataSource(self): pass
+
+class JHUBuilder(LocationSourceBuilder):
+    """The Concrete Builder"""
+    def getDataSource(self):
+        return DATA_SOURCES.get("jhu")
+
+class CSBSBuilder(LocationSourceBuilder):
+    """The Concrete Builder"""
+    def getDataSource(self):
+        return DATA_SOURCES.get("csbs")
+
+class NYTBuilder(LocationSourceBuilder):
+    """The Concrete Builder"""
+    def getDataSource(self):
+        return DATA_SOURCES.get("nyt")


### PR DESCRIPTION
The builder pattern was applied to the file that maps the three data sources. This was done to allow additional data sources to be added only interacting with one class. This allows for the separation of the data sources from its representation to create different data source representations. It ultimately helps reduce lines of code when more data sources of data wants to be included in the project. 